### PR TITLE
Destroy api

### DIFF
--- a/textile/build.gradle
+++ b/textile/build.gradle
@@ -15,7 +15,7 @@ ext {
     siteUrl = 'https://github.com/textileio/android-textile'
     gitUrl = 'https://github.com/textileio/android-textile.git'
 
-    libraryVersion = '0.1.6'
+    libraryVersion = '0.1.7'
 
     developerId = 'textile'
     developerName = 'Textile'
@@ -57,8 +57,8 @@ android {
 }
 
 dependencies {
-    api 'io.textile:pb:0.1.12-rc1'
-    api 'io.textile:mobile:0.1.12-rc1'
+    api 'io.textile:pb:0.1.12-rc3'
+    api 'io.textile:mobile:0.1.12-rc3'
     implementation "android.arch.lifecycle:extensions:1.1.1"
     annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Added a `destroy` method to the api that clears out all in memory references, allowing Textile to be re-initialized if needed. Mostly useful for the RN sdk for when the JS is "reloaded" during development. Upcoming PR in the RN sdk repo showing how that works.

Updated to go-textile 0.1.12-rc3.