### PR TITLE
Update to go-textile 0.2.6

### DIFF
--- a/textile/build.gradle
+++ b/textile/build.gradle
@@ -57,8 +57,8 @@ android {
 }
 
 dependencies {
-    api 'io.textile:pb:0.2.4'
-    api 'io.textile:mobile:0.2.4'
+    api 'io.textile:pb:0.2.6'
+    api 'io.textile:mobile:0.2.6'
     implementation "android.arch.lifecycle:extensions:1.1.1"
     annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
Bintray is up and running again, here we go.