### PR TITLE
Andrew/check listener status

### DIFF
--- a/textile/src/main/java/io/textile/textile/LifecycleService.java
+++ b/textile/src/main/java/io/textile/textile/LifecycleService.java
@@ -66,6 +66,7 @@ public class LifecycleService extends Service {
             timer = null;
         }
         Textile.instance().stop();
+        // Sometimes this function is run while nodeStoppedListener is still null, crashing the app
         if (timer != null) {
             nodeStoppedListener.onNodeStopped();
             timer = null;

--- a/textile/src/main/java/io/textile/textile/LifecycleService.java
+++ b/textile/src/main/java/io/textile/textile/LifecycleService.java
@@ -66,7 +66,10 @@ public class LifecycleService extends Service {
             timer = null;
         }
         Textile.instance().stop();
-        nodeStoppedListener.onNodeStopped();
+        if (timer != null) {
+            nodeStoppedListener.onNodeStopped();
+            timer = null;
+        }
         stopSelf();
     }
 

--- a/textile/src/main/java/io/textile/textile/LifecycleService.java
+++ b/textile/src/main/java/io/textile/textile/LifecycleService.java
@@ -67,9 +67,8 @@ public class LifecycleService extends Service {
         }
         Textile.instance().stop();
         // Sometimes this function is run while nodeStoppedListener is still null, crashing the app
-        if (timer != null) {
+        if (nodeStoppedListener != null) {
             nodeStoppedListener.onNodeStopped();
-            timer = null;
         }
         stopSelf();
     }


### PR DESCRIPTION
@asutula I don't see where this property is ever set, so maybe it's expected to be set outside of our library. so just put this simple null check as this trying to to run the method while the property is null is leading to the most android crashes right now