### PR TITLE
android-textile: add swarm connect to ipfs api

### DIFF
--- a/manifest.gradle
+++ b/manifest.gradle
@@ -39,7 +39,7 @@ ext {
     appcompatVersion = '28.0.0'
 
     // Textile
-    textileVersion = '0.7.0'
+    textileVersion = '0.7.2'
 
     // Lifecycle
     // androidxLifecycleVersion = '2.0.0'

--- a/textile/src/main/java/io/textile/textile/Ipfs.java
+++ b/textile/src/main/java/io/textile/textile/Ipfs.java
@@ -21,6 +21,17 @@ public class Ipfs extends NodeDependent {
     }
 
     /**
+     * Open a new direct connection to a peer using an IPFS multiaddr
+     * @param multiaddr Peer IPFS multiaddr
+     * @return Whether the peer swarm connect was successfull
+     * @throws Exception The exception that occurred
+     */
+    public Boolean swarmConnect(final String multiaddr) throws Exception {
+        final String result = node.swarmConnect(multiaddr);
+        return result.length() > 0;
+    }
+
+    /**
      * Get raw data stored at an IPFS path
      * @param path The IPFS path for the data you want to retrieve
      * @param handler An object that will get called with the resulting data and media type

--- a/textile/src/main/java/io/textile/textile/Textile.java
+++ b/textile/src/main/java/io/textile/textile/Textile.java
@@ -212,7 +212,7 @@ public class Textile implements LifecycleObserver {
     public static void initialize(final String repoPath, final String seed, final boolean debug, final boolean logToDisk) throws Exception {
         final InitConfig config = new InitConfig();
         config.setSeed(seed);
-        config.setRepoPath(repoPath);
+        config.setBaseRepoPath(repoPath);
         config.setLogToDisk(logToDisk);
         config.setDebug(debug);
         Mobile.initRepo(config);


### PR DESCRIPTION
Add `swarm connect` to [Update React Native APIs to match more closely the JS and Rest API](https://github.com/textileio/react-native-sdk/issues/108)

Need PR [mobile: add swarm connect to ipfs api](https://github.com/textileio/go-textile/pull/908) and set go-textile to v0.7.2 first

Additionally: Pass compile with `RepoPath -> BaseRepoPath` change in https://github.com/textileio/go-textile/commit/db375330e0e813f2c190caf3e604d3a775f06ded